### PR TITLE
feat: Integrate frontend with backend and align data structures

### DIFF
--- a/frontend/src/api/apiService.js
+++ b/frontend/src/api/apiService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:3000'; // URL do backend do seu colega
+const API_URL = 'http://localhost:8000'; // URL do backend do seu colega
 const USE_MOCK_DATA = false; // <<< MUDE PARA 'false' PARA USAR O BACKEND REAL
 
 let mockAlertas = [
@@ -17,7 +17,7 @@ export const getAlertas = () => {
         console.warn("Usando dados FALSOS (mock) para alertas.");
         return Promise.resolve({ data: { data: mockAlertas } });
     }
-    return api.get('/alertas');
+    return api.get('/painel/alertas');
 };
 
 export const createAlerta = (alertaData) => {
@@ -34,5 +34,5 @@ export const createAlerta = (alertaData) => {
         mockAlertas.push(newAlerta);
         return Promise.resolve({ data: { data: newAlerta } });
     }
-    return api.post('/alertas', alertaData);
+    return api.post('/cidadao/denuncia', alertaData);
 };

--- a/frontend/src/hooks/useAlertas.js
+++ b/frontend/src/hooks/useAlertas.js
@@ -11,7 +11,7 @@ export const useAlertas = () => {
             setLoading(true);
             setError(null);
             const response = await getAlertas();
-            setAlertas(response.data.data || []);
+            setAlertas(response.data || []);
         } catch (err) {
             setError('Não foi possível carregar os alertas.');
             console.error(err);

--- a/frontend/src/pages/CidadaoPage.tsx
+++ b/frontend/src/pages/CidadaoPage.tsx
@@ -21,7 +21,7 @@ const CidadaoPage = ({ onNavigate }) => {
         navigator.geolocation.getCurrentPosition(
             async (position) => {
                 const { latitude, longitude } = position.coords;
-                const payload = { ...formData, latitude, longitude };
+                const payload = { description: `[${formData.tipo}] ${formData.descricao}`, latitude, longitude };
 
                 try {
                     await createAlerta(payload);

--- a/frontend/src/pages/GestorPage.tsx
+++ b/frontend/src/pages/GestorPage.tsx
@@ -10,6 +10,24 @@ const GestorPage = ({ onNavigate }) => {
     const { alertas, loading, error } = useAlertas();
     const position = [-23.5505, -46.6333]; // Centro do mapa
 
+    // Transformar alertas para o formato esperado pelo frontend
+    const processedAlertas = alertas && alertas.length > 0 ? alertas.map(backendAlert => {
+        // Adicionando verificações para garantir que report e prediction existem
+        if (!backendAlert.report || !backendAlert.prediction) {
+            console.warn('Alerta com estrutura inesperada:', backendAlert);
+            return null; // Ou alguma estrutura padrão / log de erro
+        }
+        return {
+            id: backendAlert.id,
+            latitude: backendAlert.report.latitude,
+            longitude: backendAlert.report.longitude,
+            descricao: backendAlert.report.description,
+            prioridade: backendAlert.prediction.risk_level,
+            tipo: backendAlert.prediction.category,
+            equipe_sugerida: backendAlert.prediction.suggested_action,
+        };
+    }).filter(alerta => alerta !== null) : [];
+
     return (
         <div className="page-container gestor-page">
             <Header onNavigate={onNavigate} />
@@ -21,7 +39,7 @@ const GestorPage = ({ onNavigate }) => {
                         attribution='© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                     />
-                    {alertas.map(alerta => (
+                    {processedAlertas.map(alerta => (
                         <AlertaMarker key={alerta.id} alerta={alerta} />
                     ))}
                 </MapContainer>


### PR DESCRIPTION
This commit completes the integration between the React frontend and the FastAPI backend.

Key changes include:

- Updated frontend API service (`apiService.js`):
    - Corrected the backend API base URL to `http://localhost:8000`.
    - Pointed `createAlerta` to the `/cidadao/denuncia` backend endpoint.
    - Pointed `getAlertas` to the `/painel/alertas` backend endpoint.

- Aligned data models:
    - Modified `CidadaoPage.tsx` to send alert data (`description`, `latitude`, `longitude`) in the format expected by the backend's `CitizenReportInput` model. The report type is now prepended to the description.
    - Updated `useAlertas.js` to correctly parse the list of alerts from the backend response.
    - Transformed alert data in `GestorPage.tsx` to map backend fields (e.g., `report.description`, `prediction.risk_level`, `prediction.category`) to the props expected by the `AlertaMarker` component (`descricao`, `prioridade`, `tipo`).

- Ensured `AlertaMarker.jsx` uses the correct data fields for displaying alert details in popups on the map.

These changes enable the frontend to successfully create new citizen reports via the backend and display existing alerts on the manager's dashboard map, reflecting real-time data from the backend services.